### PR TITLE
Replaced '/' with '-' in cache keys

### DIFF
--- a/MapleBacon/Core/Cache.swift
+++ b/MapleBacon/Core/Cache.swift
@@ -64,8 +64,9 @@ public final class Cache {
   }
 
   private func makeCacheKey(_ key: String, identifier: String?) -> String {
-    guard let identifier = identifier, !identifier.isEmpty else { return key }
-    return key + "-" + identifier
+    let fileSafeKey = key.replacingOccurrences(of: "/", with: "-")
+    guard let identifier = identifier, !identifier.isEmpty else { return fileSafeKey }
+    return fileSafeKey + "-" + identifier
   }
   
   private func storeImageToDisk(_ image: UIImage, key: String) {

--- a/MapleBaconTests/CacheTests.swift
+++ b/MapleBaconTests/CacheTests.swift
@@ -21,7 +21,7 @@ class CacheTests: XCTestCase {
     let expectation = self.expectation(description: "Retrieve image from cache")
     let cache = Cache.default
     let image = helper.testImage()
-    let key = #function
+    let key = "http://\(#function)"
     
     cache.store(image, forKey: key) {
       cache.retrieveImage(forKey: key) { image, _ in


### PR DESCRIPTION
I believe that the cache implementation had an issue saving images from urls containing a slash ('/').  The system mistakenly interprets these backslashes as directory references, and fails to save the file when it can't find the directory.

To fix this I've changed the key generating function to replace '/' with '-'.  This issue escaped the tests as none of the test keys contained a slash, so I've also altered the first test to use a key with a slash.
