### PR TITLE
FIX Test Target - stored properties cannot be marked potentially unavailable with '@available'

### DIFF
--- a/MapleBaconTests/MapleBaconTests.swift
+++ b/MapleBaconTests/MapleBaconTests.swift
@@ -14,8 +14,20 @@ final class MapleBaconTests: XCTestCase {
 
   private let cache = Cache<UIImage>(name: "MapleBaconTests")
 
+  
+  private lazy var _subscriptions: Any? = nil
   @available(iOS 13.0, *)
-  private lazy var subscriptions: Set<AnyCancellable> = []
+  private var subscriptions: Set<AnyCancellable> {
+    get {
+      if _subscriptions == nil {
+        _subscriptions = Set<AnyCancellable>()
+      }
+      return _subscriptions as! Set<AnyCancellable>
+    }
+    set {
+      _subscriptions = newValue
+    }
+  }
 
   func testIntegration() {
     let expectation = self.expectation(description: #function)


### PR DESCRIPTION
@JanGorman 
Title: Fix Issue with '@available' on Stored Properties in Xcode 14

Body:

Problem
In Xcode 14, using the @available attribute on stored properties results in a compilation error: "stored properties cannot be marked potentially unavailable with '@available'". This restricts developers from making certain properties conditionally available based on the OS version.

Solution
I have modified the way we handle the @available attribute for stored properties. Instead of directly marking the property, I've encapsulated the property logic inside a computed property.

"I've been using your library and it's been very helpful. I truly appreciate all your hard work and effort. Thank you!" 🚀 